### PR TITLE
Add simple Flask app for math tutoring

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,2 @@
+FLASK_APP=app.py
+FLASK_ENV=development

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# jinmin
+# AI 수학 튜터 웹 애플리케이션
+
+이 프로젝트는 고등학교 상위권 학생이 수능 수학 1등급을 받을 수 있도록 돕는
+AI 튜터 챗봇의 간단한 웹 애플리케이션 예제입니다.
+
+## 주요 기능
+- 사용자가 입력한 질문을 OpenAI API로 전송하여 답변을 받아옵니다.
+- 한국어 기반의 시스템 프롬프트를 사용하여 친절하고 구조적인 설명을 제공합니다.
+
+## 실행 방법
+1. Python 의존성 설치:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. 환경 변수 `OPENAI_API_KEY`에 OpenAI API 키를 설정합니다.
+   `.env` 파일을 사용해도 됩니다.
+3. Flask 개발 서버 실행:
+   ```bash
+   flask run
+   ```
+4. 브라우저에서 `http://localhost:5000`에 접속합니다.
+
+## 파일 구조
+- `app.py` : Flask 애플리케이션 실행 파일
+- `templates/index.html` : 기본 HTML 페이지
+- `static/style.css` : 간단한 스타일 시트
+
+개발 용도로 만든 간단한 예제이므로 필요에 맞게 확장해 사용하세요.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,37 @@
+import os
+from flask import Flask, render_template, request, jsonify
+from dotenv import load_dotenv
+import openai
+
+load_dotenv()
+
+app = Flask(__name__)
+openai.api_key = os.getenv('OPENAI_API_KEY')
+
+SYSTEM_PROMPT = (
+    "너는 고등학교 상위권 여학생이 수능 수학에서 1등급을 받을 수 있도록 돕는 AI 수학 튜터야. "
+    "친절하고 따뜻하지만, 구조적이고 논리적인 설명을 제공해야 해."
+)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/ask', methods=['POST'])
+def ask():
+    user_prompt = request.form.get('prompt', '')
+    try:
+        response = openai.ChatCompletion.create(
+            model='gpt-3.5-turbo',
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt}
+            ]
+        )
+        answer = response.choices[0].message['content'].strip()
+    except Exception as e:
+        answer = f"Error: {e}"
+    return jsonify({'response': answer})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+openai
+python-dotenv

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 40px; }
+h1 { color: #2c3e50; }
+textarea { width: 80%; }
+#response { margin-top: 20px; white-space: pre-line; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <title>수학 튜터 AI</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <h1>AI 수학 튜터</h1>
+  <form id="chat-form">
+    <textarea id="prompt" placeholder="질문을 입력하세요"
+              rows="4" cols="50"></textarea>
+    <br>
+    <button type="submit">보내기</button>
+  </form>
+  <div id="response"></div>
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script>
+    $('#chat-form').on('submit', function(e) {
+      e.preventDefault();
+      var prompt = $('#prompt').val();
+      $('#response').text('로딩 중...');
+      $.post('/ask', {prompt: prompt}, function(data) {
+        $('#response').text(data.response);
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- initialize basic Flask application using OpenAI API
- add example HTML/CSS UI for chatting with the tutor
- provide requirements and environment variables
- update README with setup instructions

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ab23336c8326b47649d177798e24