### PR TITLE
Add basic QR attendance system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# jinmin
+# Attendance Automation System
+
+This repository contains a simple QR-based attendance system for academies. Students scan a QR code that opens a URL like:
+
+```
+http://<server-address>/attendance?student_id=<STUDENT_ID>
+```
+
+When the endpoint is hit, the server records the attendance in a local SQLite database and sends a KakaoTalk notification to the registered channel.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Edit `attendance/config.py` and insert your KakaoTalk API token.
+3. Run the server:
+   ```bash
+   python attendance/app.py
+   ```
+
+## Files
+
+- `attendance/app.py` – Flask application handling attendance events.
+- `attendance/database.py` – SQLite helpers.
+- `attendance/config.py` – KakaoTalk API configuration (fill in your token).
+
+## Usage
+
+Generate QR codes that point to the `/attendance` endpoint with the `student_id` query parameter. When a student scans their code, their attendance will be stored and a notification sent.

--- a/attendance/app.py
+++ b/attendance/app.py
@@ -1,0 +1,40 @@
+from flask import Flask, request, jsonify
+from datetime import datetime
+import requests
+import os
+
+from database import init_db, add_attendance
+from config import KAKAO_API_TOKEN, KAKAO_API_URL
+
+app = Flask(__name__)
+init_db()
+
+
+def send_kakao_message(student_id, timestamp):
+    """Send attendance notification via KakaoTalk."""
+    headers = {
+        "Authorization": f"Bearer {KAKAO_API_TOKEN}",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+    data = {
+        "template_object": f"{{'object_type':'text','text':'{student_id} checked in at {timestamp}','link':{{}}}}"
+    }
+    try:
+        response = requests.post(KAKAO_API_URL, headers=headers, data=data)
+        response.raise_for_status()
+    except Exception as e:
+        app.logger.error(f"Failed to send KakaoTalk message: {e}")
+
+@app.route('/attendance')
+def attendance():
+    student_id = request.args.get('student_id')
+    if not student_id:
+        return jsonify({'error': 'student_id is required'}), 400
+    timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+    add_attendance(student_id, timestamp)
+    send_kakao_message(student_id, timestamp)
+    return jsonify({'status': 'success', 'student_id': student_id, 'timestamp': timestamp})
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port)

--- a/attendance/config.py
+++ b/attendance/config.py
@@ -1,0 +1,4 @@
+# Configuration for KakaoTalk API
+# Replace these values with your actual KakaoTalk API token and URL
+KAKAO_API_TOKEN = "YOUR_KAKAO_TOKEN"
+KAKAO_API_URL = "https://kapi.kakao.com/v2/api/talk/memo/default/send"

--- a/attendance/database.py
+++ b/attendance/database.py
@@ -1,0 +1,29 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent / "attendance.db"
+
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS attendance (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            student_id TEXT NOT NULL,
+            timestamp TEXT NOT NULL
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_attendance(student_id: str, timestamp: str):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        "INSERT INTO attendance (student_id, timestamp) VALUES (?, ?)",
+        (student_id, timestamp),
+    )
+    conn.commit()
+    conn.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests


### PR DESCRIPTION
## Summary
- implement `attendance/app.py` with Flask server to record attendance via QR-coded URL
- persist attendance records in SQLite using `attendance/database.py`
- add KakaoTalk API configuration in `attendance/config.py`
- document setup and usage in `README.md`
- declare dependencies in `requirements.txt`

## Testing
- `python -m py_compile attendance/app.py attendance/database.py attendance/config.py`

------
https://chatgpt.com/codex/tasks/task_e_6847c7f85cd88326aaf348dddede91b2